### PR TITLE
Sao Paulo misspelling and Barbados

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,12 @@
                 <h2>Belize</h2>
             </div>
 
-            <div class="destination" id="barcelona">
-                <h2>Barcelona</h2>
+            <div class="destination" id="sao-paulo">
+                <h2>Sao Paulo</h2>
+            </div>
+
+            <div class="destination" id="barbados">
+                <h2>Barbados</h2>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixed a spelling error with Sao Paulo.
Also added the destination of Barbados.