### PR TITLE
Avoid repainting destination.'s text when hovering over the destination

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -40,6 +40,10 @@ body {
     text-align: center;
 }
 
+.destination h2 {
+    will-change: transform;
+}
+
 .destination:hover h2 {
     transform: rotate(0deg);
 }


### PR DESCRIPTION
When hovering over the destination its text rotation causes a browser repaint. Since it uses the `transform` CSS property to achieve this, we can also let the browser know that the transform will change (using `will-change: transform`), thus avoiding unnecessary repaints.